### PR TITLE
Lmdb storage

### DIFF
--- a/annfab/storage/__init__.py
+++ b/annfab/storage/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+
+from annfab.storage.storage_lmdb import LmdbStorage
+
+__all__ = [LmdbStorage, ]

--- a/annfab/storage/storage_lmdb.py
+++ b/annfab/storage/storage_lmdb.py
@@ -1,0 +1,61 @@
+from nearpy.storage.storage_memory import MemoryStorage
+
+
+def noop(input):
+    return input
+
+
+class LmdbStorage(MemoryStorage):
+    """
+    Only keys are stored in the storage, with the actual vector data kept
+    in an LMDB database.
+    """
+
+    def __init__(self, lmdb_env, data_conversion=None):
+        super(LmdbStorage, self).__init__()
+        self.lmdb_env = lmdb_env
+        if data_conversion:
+            self.data_conversion = data_conversion
+        else:
+            self.data_conversion = noop
+
+    def _data_exists(self, data):
+        with self.lmdb_env.begin() as txn:
+            return txn.get(data) is not None
+
+    def _get_bucket_item(self, data):
+        assert self._data_exists(data)
+
+        with self.lmdb_env.begin() as txn:
+            value = txn.get(data)
+            assert value is not None
+
+            return self.data_conversion(value), data
+
+    def store_vector(self, hash_name, bucket_key, v, data):
+        """
+        Stores vector and JSON-serializable data in bucket with specified key.
+        """
+
+        # TODO: Ensure that the vector exists in the database
+        assert self._data_exists(data)
+
+        # Store only the data (not the vector) in memory.
+        super(LmdbStorage, self).store_vector(hash_name, bucket_key, None,
+                                              data)
+
+    def get_bucket(self, hash_name, bucket_key):
+        """
+        Returns bucket content as list of tuples (vector, data).
+        """
+        buckets = super(LmdbStorage, self).get_bucket(hash_name, bucket_key)
+
+        if not buckets:
+            return buckets
+
+        for i in range(len(buckets)):
+            # For each entry in the bucket, replace the None vector with the
+            # correct one from the lmdb database.
+            buckets[i] = self._get_bucket_item(buckets[i][1])
+
+        return buckets

--- a/annfab/tests/test_lmdb_storage.py
+++ b/annfab/tests/test_lmdb_storage.py
@@ -1,0 +1,75 @@
+import pytest
+
+from annfab.storage import LmdbStorage
+
+
+class MockLMDB(object):
+    def __init__(self, value):
+        self.value = value
+
+    def begin(self):
+        return self
+
+    def get(self, key):
+        return self.value
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+def test_store_invalid_vector_asserts():
+    db = MockLMDB(None)
+
+    sut = LmdbStorage(db)
+
+    with pytest.raises(Exception):
+        sut.store_vector('hash_name', 'bucket_key', 'v', 'key')
+
+
+def test_store_valid_vector_succeeds():
+    db = MockLMDB('vector')
+
+    sut = LmdbStorage(db)
+    sut.store_vector('hash_name', 'bucket_key', 'v', 'key')
+
+    assert 'hash_name' in sut.buckets
+    assert 'bucket_key' in sut.buckets['hash_name']
+    assert (None, 'key') == sut.buckets['hash_name']['bucket_key'][-1]
+
+
+def test_bucket_is_empty():
+    db = MockLMDB(None)
+
+    sut = LmdbStorage(db)
+
+    assert len(sut.get_bucket('hash_name', 'bucket_key')) == 0
+
+
+def test_get_bucket_sets_value():
+    db = MockLMDB('vector')
+
+    sut = LmdbStorage(db)
+    sut.store_vector('hash_name', 'bucket_key', 'v', 'key')
+
+    buckets = sut.get_bucket('hash_name', 'bucket_key')
+
+    assert len(buckets) == 1
+    assert buckets[0] == ('vector', 'key')
+
+
+def test_store_vector_maps_value():
+    def duplicate(x):
+        return x + x
+
+    db = MockLMDB('vector')
+
+    sut = LmdbStorage(db, duplicate)
+    sut.store_vector('hash_name', 'bucket_key', 'v', 'key')
+
+    buckets = sut.get_bucket('hash_name', 'bucket_key')
+
+    assert len(buckets) == 1
+    assert buckets[0] == ('vectorvector', 'key')


### PR DESCRIPTION
Implement a storage class where lmdb is used to store data. The hash buckets only contain the key used to search the database so that this does not need to be saved when writing a configuration to disk.